### PR TITLE
Use single `AxiosInstance` instead of creating a new one on each request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IDEs
+.idea/

--- a/appCluster.js
+++ b/appCluster.js
@@ -107,6 +107,9 @@ if (cluster.isWorker) {
     httpsAgent: agent,
   };
 
+  // https://www.npmjs.com/package/axios#creating-an-instance
+  const httpclient = axios.create(crateApiConfig);
+
   const STATEMENT = {
     dropTable: sqlGenerator.getDropTable(options.table),
     createTable: sqlGenerator.getCreateTable(options.table, options.shards),
@@ -132,7 +135,7 @@ if (cluster.isWorker) {
   };
 
   async function request(body) {
-    return axios.post(crateApi, body, crateApiConfig);
+    return httpclient.post(crateApi, body);
   }
 
   async function prepareTable() {


### PR DESCRIPTION
Hi,

I haven't actually tested this patch, but it might save some additional cycles by reusing the same `AxiosInstance` object for multiple subsequent HTTP requests.

With kind regards,
Andreas.
