### PR TITLE
Fix a missing rename

### DIFF
--- a/appCluster.js
+++ b/appCluster.js
@@ -143,7 +143,7 @@ if (cluster.isWorker) {
 
   function getNewBufferSync() {
     return new Array(options.concurrentRequests).fill(
-      dataGenerator.getCPUObjectBulkArray(options.batchsize, options.extraTagsLength),
+      dataGenerator.getCPUObjectBulkArray(options.batchSize, options.extraTagsLength),
     );
   }
 


### PR DESCRIPTION
Forgot to rename one instance of `batchsize` in the previous commit (58d16d81da9788f31d8799da3383d4c44960d9f4)